### PR TITLE
Prevent multiple instances of iMCP from running on a system

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -8,6 +8,9 @@
 		<key>LSUIElement</key>
 		<true />
 
+		<key>LSMultipleInstancesProhibited</key>
+		<true />
+
 		<key>NSBonjourServices</key>
 		<array>
 			<string>_mcp._tcp</string>


### PR DESCRIPTION
From [Apple's Launch Service Keys docs](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/plist/info/LSSupportsOpeningDocumentsInPlace):

> ### LSMultipleInstancesProhibited
>
> `LSMultipleInstancesProhibited` (Boolean - macOS) indicates whether an app is prohibited from running simultaneously in multiple user sessions. If true, the app runs in only one user session at a time. You can use this key to prevent resource conflicts that might arise by sharing an app across multiple user sessions. For example, you might want to prevent users from accessing a custom USB device when it is already in use by a different user.
>
> Launch Services returns an appropriate error code if the target app cannot be launched. If a user in another session is running the app, Launch Services returns a `kLSMultipleSessionsNotSupportedErr` error. If you attempt to launch a separate instance of an app in the current session, it returns `kLSMultipleInstancesProhibitedErr`.

